### PR TITLE
Added 'beta' subcommand which is a namespace for commands whose inter…

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -50,9 +50,11 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=stdc++");
     } else {
         // TODO support Windows/Unixes/etc. correctly
-        unimplemented!("Linking C++ is not yet supported on this platform {}", target);
+        unimplemented!(
+            "Linking C++ is not yet supported on this platform {}",
+            target
+        );
     }
-
 
     // ion-c CLI library
     println!("cargo:rustc-link-search=native=./ion-c/build/release/build/tools/cli/");

--- a/src/bin/ion/commands/beta.rs
+++ b/src/bin/ion/commands/beta.rs
@@ -1,0 +1,24 @@
+use clap::{App, ArgMatches};
+
+use crate::commands::dump;
+
+
+//Modify beta-support command here
+pub fn generate_subcmd() -> Vec<App<'static, 'static>> {
+    vec![dump::app()]
+}
+
+//Modify beta-support runner here
+pub fn run(command_name: &str, matches: &ArgMatches<'static>){
+    let (command_name, command_args) = matches.subcommand();
+    match command_name {
+        "dump" => dump::run(command_name, command_args.unwrap()),
+        _ => (),
+    }
+}
+
+pub fn app() -> App<'static, 'static> {
+    App::new("beta")
+        .about("The 'beta' command is a namespace for commands whose interfaces are not yet stable.")
+        .subcommands(generate_subcmd())
+}

--- a/src/bin/ion/commands/beta.rs
+++ b/src/bin/ion/commands/beta.rs
@@ -1,24 +1,22 @@
 use clap::{App, ArgMatches};
 
-use crate::commands::dump;
-
-
 //Modify beta-support command here
 pub fn generate_subcmd() -> Vec<App<'static, 'static>> {
-    vec![dump::app()]
+    vec![]
 }
 
 //Modify beta-support runner here
-pub fn run(command_name: &str, matches: &ArgMatches<'static>){
+pub fn run(command_name: &str, matches: &ArgMatches<'static>) {
     let (command_name, command_args) = matches.subcommand();
     match command_name {
-        "dump" => dump::run(command_name, command_args.unwrap()),
         _ => (),
     }
 }
 
 pub fn app() -> App<'static, 'static> {
     App::new("beta")
-        .about("The 'beta' command is a namespace for commands whose interfaces are not yet stable.")
+        .about(
+            "The 'beta' command is a namespace for commands whose interfaces are not yet stable.",
+        )
         .subcommands(generate_subcmd())
 }

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -1,16 +1,18 @@
 use clap::{App, ArgMatches};
 
 pub mod dump;
+pub mod beta;
 
 // Creates a Vec of CLI configurations for all of the available built-in commands
 pub fn built_in_commands() -> Vec<App<'static, 'static>> {
-    vec![dump::app()]
+    vec![dump::app(), beta::app()]
 }
 
 // Maps the given command name to the entry point for that command if it exists
 pub fn runner_for_built_in_command(command_name: &str) -> Option<fn(&str, &ArgMatches<'static>)> {
     let runner = match command_name {
         "dump" => dump::run,
+        "beta" => beta::run,
         _ => return None,
     };
     Some(runner)

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -1,7 +1,7 @@
 use clap::{App, ArgMatches};
 
-pub mod dump;
 pub mod beta;
+pub mod dump;
 
 // Creates a Vec of CLI configurations for all of the available built-in commands
 pub fn built_in_commands() -> Vec<App<'static, 'static>> {


### PR DESCRIPTION
### Description:
Implemented beta which is a namespace for commands whose interfaces are not yet stable.
We can add new command to beta stage by modify fn in line 6 and line 11 in `beta.rs`.
&nbsp;
### Example:
**This example suppose that `dump` is in beta stage. We can see that dump in the **subcommand** section of beta.**
&nbsp;
![Screen Shot 2021-01-14 at 10 28 55 AM](https://user-images.githubusercontent.com/67451029/104632971-513a9480-5653-11eb-838b-220faa676577.png)

&nbsp;
&nbsp;
**I have a file 1.txt with text `a`, use `beta dump` command to dump file in text type:**
![Screen Shot 2021-01-14 at 10 41 29 AM](https://user-images.githubusercontent.com/67451029/104634140-15083380-5655-11eb-8a8a-b14829370035.png)

&nbsp;
### Test:
manually test.

&nbsp;
### Post work:
After this Pr is approved, I'll remove `dump` from `beta` and make a new PR target to official repo.


&nbsp;

